### PR TITLE
Setup NAT for configcontroller cluster

### DIFF
--- a/infra/configcontroller/configcontroller.yaml
+++ b/infra/configcontroller/configcontroller.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: binding
 spec:
   location: us-central1
+  projectRef:
+    # project "googleprojectid" should be updated
+    external: "projects/googleprojectid"
   managementConfig:
     standardManagementConfig:
       masterIPv4CidrBlock: 172.16.0.128/28

--- a/infra/configcontroller/configcontroller.yaml
+++ b/infra/configcontroller/configcontroller.yaml
@@ -8,3 +8,7 @@ spec:
   managementConfig:
     standardManagementConfig:
       masterIPv4CidrBlock: 172.16.0.128/28
+      networkRef:
+        name: default
+        # namespace "binding" should be updated
+        namespace: binding

--- a/infra/configcontroller/nat.yaml
+++ b/infra/configcontroller/nat.yaml
@@ -1,0 +1,79 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# TODO: The KCC resources should be under "binding" namespace. 
+# This requires updating the function to update spec namespace references.
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRouterNAT
+metadata:
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+  name: default
+  namespace: binding
+spec:
+  region: us-central1
+  natIpAllocateOption: AUTO_ONLY
+  routerRef:
+    name: default
+    # namespace "binding" should be updated
+    namespace: binding
+  sourceSubnetworkIpRangesToNat: LIST_OF_SUBNETWORKS
+  subnetwork:
+  - subnetworkRef:
+      name: default
+      # namespace "binding" should be updated
+      namespace: binding
+    sourceIpRangesToNat:
+    - ALL_IP_RANGES
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeNetwork
+metadata:
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+  name: default
+  namespace: binding
+spec:
+  routingMode: REGIONAL
+  autoCreateSubnetworks: false
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeRouter
+metadata:
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+  name: default
+  namespace: binding
+spec:
+  description: example router description
+  region: us-central1
+  networkRef:
+    name: default
+    # namespace "binding" should be updated
+    namespace: binding
+---
+apiVersion: compute.cnrm.cloud.google.com/v1beta1
+kind: ComputeSubnetwork
+metadata:
+  annotations:
+    cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
+  name: default
+  namespace: binding
+spec:
+  description: ConfigController subnet
+  ipCidrRange: 192.168.1.0/24
+  region: us-central1
+  networkRef:
+    name: default
+    # namespace "binding" should be updated
+    namespace: binding

--- a/infra/configcontroller/nat.yaml
+++ b/infra/configcontroller/nat.yaml
@@ -30,7 +30,7 @@ spec:
   sourceSubnetworkIpRangesToNat: LIST_OF_SUBNETWORKS
   subnetwork:
   - subnetworkRef:
-      name: default
+      name: custom
       # namespace "binding" should be updated
       namespace: binding
     sourceIpRangesToNat:
@@ -45,7 +45,13 @@ metadata:
   namespace: binding
 spec:
   routingMode: REGIONAL
-  autoCreateSubnetworks: false
+  # ConfigControllerInstance does not support the "subnet" interface.
+  # Thus disabling the `autoCreateSubnetWorks` will cause 
+  # the configcontroller to complain about 
+  # "network uses manual subnet mode and requires specifying a subnetwork" issue. 
+  # As a workaround, we let the network to create subnet in each region,
+  # and manually create a standalone NAT, router and subnetwork in that network. 
+  autoCreateSubnetworks: true
 ---
 apiVersion: compute.cnrm.cloud.google.com/v1beta1
 kind: ComputeRouter
@@ -67,7 +73,10 @@ kind: ComputeSubnetwork
 metadata:
   annotations:
     cnrm.cloud.google.com/blueprint: 'kpt-fn-live'
-  name: default
+  # With ComputeNetwork `autoCreateSubnetworks: true`,
+  # all region will have a subnetwork named "default", 
+  # to avoid conflict, we use a different subnet name.
+  name: custom
   namespace: binding
 spec:
   description: ConfigController subnet


### PR DESCRIPTION
### Description
The config controller cluster is [a private cluster](https://cloud.google.com/nat/docs/gke-example) and the nodes are not bound with internet access. We need to set up the cloud NAT, so that the config controller (specifically config sync) can run git operations. 

### ConfigController SubNetwork issue
 The `ConfigControllerInstance` does not support customizing the subnetwork ( `gcloud` supports this feature  via `subnet` flag in a later version). In such condition, if the config controller network is in manual subnet mode (preferred), the config controller will fail because its cluster does not have the subnetwork configured.

#### Error message:
"network uses manual subnet mode and requires specifying a subnetwork"

#### Solution
This PR proposes to set `ComputeNetwork` in auto mode and let it create the subnetworks in each region. This can bypass the Config controller cluster problem. Then, it creates another subnetwork the `ComputeRouterNAT` object can refer to, and the custom subnet will use a different name to avoid conflict with the auto created subnet. 
 
### `spec.projectRef`  issue

`ConfigControllerInstance` does not support the namespace bound "project-id" annotation. It specifically requests the GCP project to be provided in the `spec.projectRef` field.  

Reference CNRM documentations 
Network: https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computenetwork
NAT: https://cloud.google.com/config-connector/docs/reference/resource-docs/compute/computerouternat
ConfigController: https://cloud.google.com/config-connector/docs/reference/resource-docs/configcontroller/configcontrollerinstance